### PR TITLE
Delete add_user_to_quick_tweet.rb

### DIFF
--- a/app/models/add_user_to_quick_tweet.rb
+++ b/app/models/add_user_to_quick_tweet.rb
@@ -1,6 +1,0 @@
-class AddUserToQuickTweet < ApplicationRecord
-  # Include default devise modules. Others available are:
-  # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
-  devise :database_authenticatable, :registerable,
-         :recoverable, :rememberable, :validatable
-end


### PR DESCRIPTION
looks like you wanted to `rails g migration`, but did `rails g model` 🤔  